### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pip install -e .                 # 以开发模式安装项目本身
 项目依赖以下主要包：
 
 - **openai>=1.72.0** - OpenAI API客户端，用于与DeepSeek API交互
-- **pyautogen>=0.8.5** - AutoGen框架，用于构建AI代理
+- **ag2>=0.8.5** - AutoGen框架，用于构建AI代理
 - **pandas & numpy** - 数据处理核心组件
 - **matplotlib>=3.10.0** - 用于数据可视化
 - **akshare>=1.16.0** - 中国金融数据接口

--- a/TEST_REPORT.md
+++ b/TEST_REPORT.md
@@ -10,7 +10,7 @@
 - **Python版本**: 3.13
 - **依赖包**: 
   - openai>=1.72.0
-  - pyautogen>=0.8.5
+  - ag2>=0.8.5
   - requests>=2.31.0
   - pandas
   - numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 # ========= 版本兼容组合选项 =========
 
 # OpenAI和AutoGen相关
-openai>=1.72.0  # 新版API，需要与pyautogen兼容
-pyautogen>=0.8.5  # 需要Rust编译，与新版openai兼容
+openai>=1.72.0  # 新版API，需要与ag2兼容
+ag2>=0.8.5  # 需要Rust编译，与新版openai兼容
 
 # 选项3：最小依赖（仅基本功能）
 requests>=2.31.0  # 用于API请求


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
