### PR TITLE
Add AGENTS.md with cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,21 @@ python3 -m deepseek_finrobot.cli --help
 
 Full CLI commands (predict, industry, portfolio, etc.) require a valid `DEEPSEEK_API_KEY` in either the environment or `config_api_keys.json` at project root (copy from `config_api_keys_sample`).
 
+**Important**: The CLI's `predict` command (and other agent commands) uses AutoGen's conversation loop, which may run for many minutes due to auto-reply behavior. For quick validation, use the Python API directly (e.g. `get_completion()` from `deepseek_finrobot.openai_adapter`).
+
+### CLI config_api_keys.json setup
+
+The CLI requires `config_api_keys.json` at the project root. If `DEEPSEEK_API_KEY` is set in the environment, create it with:
+
+```python
+import json, os
+with open('config_api_keys.json', 'w') as f:
+    json.dump({'DEEPSEEK_API_KEY': os.environ['DEEPSEEK_API_KEY']}, f)
+```
+
+Remember to delete this file before committing (it's not gitignored).
+
 ### External dependencies
 
 - **DeepSeek API**: Requires `DEEPSEEK_API_KEY` for any LLM-powered agent functionality.
-- **AKShare**: Fetches live Chinese financial data from public APIs (no key needed, but requires internet access). Some endpoints may transiently fail; the code has fallback logic.
+- **AKShare**: Fetches live Chinese financial data from public APIs (no key needed, but requires internet access). The primary `akshare` endpoint for industry lists sometimes fails with `RemoteDisconnected`; the code has built-in fallback logic that usually succeeds on retry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+DeepSeek FinRobot is a Chinese financial AI agent platform built on the DeepSeek LLM API. It is a **CLI-only Python library** — no web server, database, or Docker required. See `README.md` for full architecture and usage examples.
+
+### Key dependency caveat
+
+The code imports `autogen` (the v0.2 API of pyautogen), but `requirements.txt` specifies `pyautogen>=0.8.5` which installs the newer v0.4+ package that no longer exposes the `autogen` module. You **must** install `pyautogen==0.2.35` to get the correct `import autogen` compatibility. The update script handles this automatically.
+
+### Running tests
+
+```bash
+python3 -m pytest tests/ -v
+```
+
+All 7 tests pass without a DeepSeek API key. Tests that would call the API are skipped when `DEEPSEEK_API_KEY` is not set.
+
+For coverage: `python3 -m pytest tests/ -v --cov=deepseek_finrobot --cov-report=term`
+
+### Linting
+
+No linter is configured in the repo. You can use `ruff check deepseek_finrobot/ tests/` for basic checks. Pre-existing lint findings are expected.
+
+### Running the CLI
+
+```bash
+python3 -m deepseek_finrobot.cli --help
+```
+
+Full CLI commands (predict, industry, portfolio, etc.) require a valid `DEEPSEEK_API_KEY` in either the environment or `config_api_keys.json` at project root (copy from `config_api_keys_sample`).
+
+### External dependencies
+
+- **DeepSeek API**: Requires `DEEPSEEK_API_KEY` for any LLM-powered agent functionality.
+- **AKShare**: Fetches live Chinese financial data from public APIs (no key needed, but requires internet access). Some endpoints may transiently fail; the code has fallback logic.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with cloud-specific development environment instructions for future Cursor Cloud agents.

### What's included

- Project overview and key dependency caveat (`pyautogen==0.2.35` required for `import autogen` compatibility)
- Commands for running tests, linting, and the CLI
- Notes on external dependencies (DeepSeek API key, AKShare)
- CLI config setup and AutoGen conversation loop caveat (discovered during hello world testing)

### Environment setup verified

| Check | Status |
|-------|--------|
| `pip install -r requirements.txt` | ✅ |
| `pip install pyautogen==0.2.35` | ✅ |
| `pip install -e .` | ✅ |
| `python3 -m pytest tests/ -v` | ✅ 7/7 passed |
| `ruff check deepseek_finrobot/ tests/` | ⚠️ Pre-existing findings |
| `python3 -m deepseek_finrobot.cli --help` | ✅ |
| DeepSeek API `get_completion()` | ✅ |
| DeepSeek API `get_chat_completion()` | ✅ |
| AKShare data fetch (84 industries) | ✅ |
| AutoGen agent creation | ✅ |
| CLI `predict 000001` (full e2e) | ✅ |

### Hello world task

Successfully ran end-to-end: utility functions, AKShare live data fetch (84 industry sectors), DeepSeek API single-turn and multi-turn calls, AutoGen config generation, and a full CLI stock prediction for 平安银行 (000001).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9eb8c8a0-4287-4851-bf67-5a1395d727d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eb8c8a0-4287-4851-bf67-5a1395d727d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

