### PR TITLE
Pin autogen-compatible dependency and add intelligent stock selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pip install -e .                 # 以开发模式安装项目本身
 项目依赖以下主要包：
 
 - **openai>=1.72.0** - OpenAI API客户端，用于与DeepSeek API交互
-- **pyautogen>=0.8.5** - AutoGen框架，用于构建AI代理
+- **pyautogen==0.2.35** - 锁定到提供 `autogen` 模块的稳定版本（与当前代理实现兼容）
 - **pandas & numpy** - 数据处理核心组件
 - **matplotlib>=3.10.0** - 用于数据可视化
 - **akshare>=1.16.0** - 中国金融数据接口

--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ python -m deepseek_finrobot.cli industry 银行 --days 30 --export（已经测�
 
 # 分析财经新闻
 python -m deepseek_finrobot.cli news 人工智能 --days 3 --limit 10 （未测试）
+
+# 智能选股（多因子，候选池手动指定）
+python -m deepseek_finrobot.cli select --stocks 000001,600036,600519,000858 --top 3 --risk 中等 --horizon 中期
+
+# 智能选股（按行业自动扩展候选池 + AutoGen多代理共识）
+python -m deepseek_finrobot.cli select --industry-name 银行 --top 5 --risk 保守 --horizon 长期 --consensus
 ```
 
 ## 直接使用DeepSeek API适配器

--- a/TEST_REPORT.md
+++ b/TEST_REPORT.md
@@ -10,7 +10,7 @@
 - **Python版本**: 3.13
 - **依赖包**: 
   - openai>=1.72.0
-  - pyautogen>=0.8.5
+  - pyautogen==0.2.35
   - requests>=2.31.0
   - pandas
   - numpy

--- a/deepseek_finrobot/agents/__init__.py
+++ b/deepseek_finrobot/agents/__init__.py
@@ -3,6 +3,7 @@
 """
 
 from .agent_library import MarketForecasterAgent, FinancialReportAgent, NewsAnalysisAgent, IndustryAnalysisAgent, PortfolioManagerAgent, TechnicalAnalysisAgent
+from .selection_agent import StockSelectorAgent
 from .workflow import SingleAssistant, SingleAssistantShadow, MultiAgentWorkflow
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     'IndustryAnalysisAgent',
     'PortfolioManagerAgent',
     'TechnicalAnalysisAgent',
+    'StockSelectorAgent',
     'SingleAssistant',
     'SingleAssistantShadow',
     'MultiAgentWorkflow'

--- a/deepseek_finrobot/agents/selection_agent.py
+++ b/deepseek_finrobot/agents/selection_agent.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import datetime
 import json
 import math
+import os
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -313,6 +314,7 @@ class StockSelectorAgent:
         """
         try:
             # region agent log
+            os.makedirs("/opt/cursor/logs", exist_ok=True)
             open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
                 json.dumps(
                     {
@@ -345,6 +347,7 @@ class StockSelectorAgent:
                 metrics.append(m)
             try:
                 # region agent log
+                os.makedirs("/opt/cursor/logs", exist_ok=True)
                 open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
                     json.dumps(
                         {

--- a/deepseek_finrobot/agents/selection_agent.py
+++ b/deepseek_finrobot/agents/selection_agent.py
@@ -342,7 +342,12 @@ class StockSelectorAgent:
 
         metrics = []
         for symbol in unique_symbols:
-            m = self._collect_symbol_metrics(symbol)
+            try:
+                m = self._collect_symbol_metrics(symbol)
+            except Exception as e:
+                # 单个标的网络抖动不应导致整轮选股失败
+                print(f"采集股票 {symbol} 指标失败，已跳过: {e}")
+                m = None
             if m:
                 metrics.append(m)
             try:

--- a/deepseek_finrobot/agents/selection_agent.py
+++ b/deepseek_finrobot/agents/selection_agent.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import datetime
 import json
 import math
-import os
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -312,26 +311,6 @@ class StockSelectorAgent:
         """
         多因子智能选股。
         """
-        try:
-            # region agent log
-            os.makedirs("/opt/cursor/logs", exist_ok=True)
-            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-                json.dumps(
-                    {
-                        "hypothesisId": "A",
-                        "location": "selection_agent.py:302",
-                        "message": "select_stocks_entry",
-                        "data": {"input_symbol_count": len(symbols), "top_n": top_n},
-                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                    },
-                    ensure_ascii=False,
-                )
-                + "\n"
-            )
-            # endregion
-        except Exception:
-            pass
-
         unique_symbols = []
         seen = set()
         for s in symbols:
@@ -350,26 +329,6 @@ class StockSelectorAgent:
                 m = None
             if m:
                 metrics.append(m)
-            try:
-                # region agent log
-                os.makedirs("/opt/cursor/logs", exist_ok=True)
-                open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-                    json.dumps(
-                        {
-                            "hypothesisId": "A",
-                            "location": "selection_agent.py:323",
-                            "message": "collect_symbol_metrics_result",
-                            "data": {"symbol": symbol, "success": bool(m)},
-                            "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                        },
-                        ensure_ascii=False,
-                    )
-                    + "\n"
-                )
-                # endregion
-            except Exception:
-                pass
-
         if not metrics:
             return {
                 "error": "没有可用的候选股票数据，请检查候选池或稍后重试。",

--- a/deepseek_finrobot/agents/selection_agent.py
+++ b/deepseek_finrobot/agents/selection_agent.py
@@ -311,6 +311,25 @@ class StockSelectorAgent:
         """
         多因子智能选股。
         """
+        try:
+            # region agent log
+            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+                json.dumps(
+                    {
+                        "hypothesisId": "A",
+                        "location": "selection_agent.py:302",
+                        "message": "select_stocks_entry",
+                        "data": {"input_symbol_count": len(symbols), "top_n": top_n},
+                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+            # endregion
+        except Exception:
+            pass
+
         unique_symbols = []
         seen = set()
         for s in symbols:
@@ -324,6 +343,24 @@ class StockSelectorAgent:
             m = self._collect_symbol_metrics(symbol)
             if m:
                 metrics.append(m)
+            try:
+                # region agent log
+                open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+                    json.dumps(
+                        {
+                            "hypothesisId": "A",
+                            "location": "selection_agent.py:323",
+                            "message": "collect_symbol_metrics_result",
+                            "data": {"symbol": symbol, "success": bool(m)},
+                            "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+                # endregion
+            except Exception:
+                pass
 
         if not metrics:
             return {

--- a/deepseek_finrobot/agents/selection_agent.py
+++ b/deepseek_finrobot/agents/selection_agent.py
@@ -1,0 +1,496 @@
+"""
+智能选股代理 - 提供多因子量化选股与多代理共识能力
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import math
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import autogen
+import numpy as np
+import pandas as pd
+
+from ..data_source import akshare_utils, cn_news_utils
+
+
+class StockSelectorAgent:
+    """
+    智能选股代理
+
+    特性：
+    1) 多因子评分：动量、波动、估值、流动性、质量
+    2) 权重自适应：根据风险偏好和投资期限动态调整
+    3) 分散约束：限制单一行业入选数量
+    4) AutoGen群聊共识（可选）：量化/基本面/风控多代理协同给出结论
+    """
+
+    def __init__(self, llm_config: Optional[Dict[str, Any]] = None):
+        self.llm_config = llm_config
+
+    @staticmethod
+    def _safe_float(value: Any) -> float:
+        """将任意输入尽可能转换为float，失败时返回NaN。"""
+        if value is None:
+            return np.nan
+        if isinstance(value, (int, float, np.integer, np.floating)):
+            return float(value)
+        if isinstance(value, str):
+            cleaned = value.strip().replace(",", "")
+            if cleaned in {"", "N/A", "nan", "None", "--"}:
+                return np.nan
+            matched = re.search(r"-?\d+(\.\d+)?", cleaned)
+            if matched:
+                try:
+                    return float(matched.group(0))
+                except ValueError:
+                    return np.nan
+        return np.nan
+
+    @staticmethod
+    def _extract_metric(df: pd.DataFrame, candidate_columns: List[str]) -> float:
+        """从财务DataFrame中按候选列提取首个可用数值。"""
+        if df is None or df.empty:
+            return np.nan
+        for col in candidate_columns:
+            if col in df.columns:
+                series = pd.to_numeric(df[col], errors="coerce").dropna()
+                if not series.empty:
+                    return float(series.iloc[0])
+        return np.nan
+
+    @staticmethod
+    def _normalize(values: List[float], reverse: bool = False) -> List[float]:
+        """Min-Max归一化，缺失值回填0.5。"""
+        arr = np.array(values, dtype=float)
+        valid_mask = np.isfinite(arr)
+        if valid_mask.sum() == 0:
+            return [0.5] * len(values)
+
+        valid = arr[valid_mask]
+        v_min = float(np.min(valid))
+        v_max = float(np.max(valid))
+
+        norm = np.full_like(arr, 0.5, dtype=float)
+        if not math.isclose(v_min, v_max):
+            norm[valid_mask] = (valid - v_min) / (v_max - v_min)
+        else:
+            norm[valid_mask] = 0.5
+
+        if reverse:
+            norm = 1.0 - norm
+        return np.clip(norm, 0.0, 1.0).tolist()
+
+    @staticmethod
+    def _risk_weights(risk_preference: str) -> Dict[str, float]:
+        """不同风险偏好的基础因子权重。"""
+        mapping = {
+            "保守": {
+                "quality": 0.30,
+                "valuation": 0.25,
+                "momentum": 0.10,
+                "volatility": 0.25,
+                "liquidity": 0.10,
+            },
+            "中等": {
+                "quality": 0.22,
+                "valuation": 0.20,
+                "momentum": 0.25,
+                "volatility": 0.15,
+                "liquidity": 0.18,
+            },
+            "激进": {
+                "quality": 0.15,
+                "valuation": 0.10,
+                "momentum": 0.40,
+                "volatility": 0.10,
+                "liquidity": 0.25,
+            },
+        }
+        return mapping.get(risk_preference, mapping["中等"]).copy()
+
+    @staticmethod
+    def _horizon_adjustments(investment_horizon: str) -> Dict[str, float]:
+        """不同投资期限对因子进行再加权。"""
+        mapping = {
+            "短期": {
+                "quality": 0.85,
+                "valuation": 0.85,
+                "momentum": 1.25,
+                "volatility": 1.10,
+                "liquidity": 1.20,
+            },
+            "中期": {
+                "quality": 1.00,
+                "valuation": 1.00,
+                "momentum": 1.00,
+                "volatility": 1.00,
+                "liquidity": 1.00,
+            },
+            "长期": {
+                "quality": 1.25,
+                "valuation": 1.20,
+                "momentum": 0.85,
+                "volatility": 0.95,
+                "liquidity": 0.90,
+            },
+        }
+        return mapping.get(investment_horizon, mapping["中期"]).copy()
+
+    def _build_final_weights(self, risk_preference: str, investment_horizon: str) -> Dict[str, float]:
+        """融合风险偏好与投资期限，得到最终权重。"""
+        base = self._risk_weights(risk_preference)
+        adj = self._horizon_adjustments(investment_horizon)
+        weighted = {k: base[k] * adj.get(k, 1.0) for k in base}
+        total = sum(weighted.values()) or 1.0
+        return {k: v / total for k, v in weighted.items()}
+
+    def _collect_symbol_metrics(self, symbol: str, lookback_days: int = 260) -> Optional[Dict[str, Any]]:
+        """采集单个股票的多因子原始指标。"""
+        info = akshare_utils.get_stock_info(symbol)
+        if not info or "error" in info:
+            return None
+
+        end_date = datetime.datetime.now().strftime("%Y%m%d")
+        start_date = (datetime.datetime.now() - datetime.timedelta(days=lookback_days)).strftime("%Y%m%d")
+        history = akshare_utils.get_stock_history(symbol, start_date=start_date, end_date=end_date)
+        if history is None or history.empty or "收盘" not in history.columns:
+            return None
+
+        close = pd.to_numeric(history["收盘"], errors="coerce").dropna()
+        if len(close) < 30:
+            return None
+
+        volume_series = pd.to_numeric(history["成交量"], errors="coerce").dropna() if "成交量" in history.columns else pd.Series(dtype=float)
+        returns = close.pct_change().dropna()
+
+        momentum_20 = float(close.iloc[-1] / close.iloc[-21] - 1.0) if len(close) > 21 else np.nan
+        momentum_60 = float(close.iloc[-1] / close.iloc[-61] - 1.0) if len(close) > 61 else np.nan
+        trend_win_rate = float((returns.tail(60) > 0).mean()) if len(returns) >= 20 else np.nan
+        volatility_60 = float(returns.tail(60).std() * math.sqrt(252)) if len(returns) >= 20 else np.nan
+
+        pe = self._safe_float(info.get("市盈率(动态)", info.get("市盈率")))
+        pb = self._safe_float(info.get("市净率"))
+        liquidity = float(volume_series.tail(20).mean()) if not volume_series.empty else self._safe_float(info.get("成交量"))
+
+        financial = akshare_utils.get_stock_financial_indicator(symbol)
+        roe = self._extract_metric(financial, ["净资产收益率(%)", "净资产收益率", "ROE", "净资产收益率-摊薄"])
+        profit_growth = self._extract_metric(financial, ["净利润同比增长率(%)", "净利润同比增长率", "净利润同比"])
+        revenue_growth = self._extract_metric(financial, ["营业收入同比增长率(%)", "营业收入同比增长率", "营业收入同比"])
+
+        quality_components = [x for x in [roe, profit_growth, revenue_growth] if np.isfinite(x)]
+        quality_raw = float(np.mean(quality_components)) if quality_components else np.nan
+
+        momentum_raw = float(np.nanmean([momentum_20, momentum_60])) if np.isfinite(momentum_20) or np.isfinite(momentum_60) else np.nan
+        valuation_raw = float(np.nanmean([pe, pb])) if np.isfinite(pe) or np.isfinite(pb) else np.nan
+
+        return {
+            "symbol": symbol,
+            "name": info.get("股票简称", symbol),
+            "industry": info.get("所处行业", "未知") or "未知",
+            "raw_metrics": {
+                "momentum_raw": momentum_raw,
+                "trend_win_rate": trend_win_rate,
+                "volatility_raw": volatility_60,
+                "valuation_raw": valuation_raw,
+                "liquidity_raw": liquidity,
+                "quality_raw": quality_raw,
+                "pe": pe,
+                "pb": pb,
+                "roe": roe,
+                "profit_growth": profit_growth,
+                "revenue_growth": revenue_growth,
+            },
+        }
+
+    @staticmethod
+    def _market_regime_bias(market_sentiment: Optional[Dict[str, Any]]) -> Dict[str, float]:
+        """根据市场情绪给出因子偏置（轻量，避免过拟合）。"""
+        if not market_sentiment or "error" in market_sentiment:
+            return {"momentum": 0.0, "valuation": 0.0, "volatility": 0.0}
+
+        trend = market_sentiment.get("market_trend", {})
+        sentiment = trend.get("sentiment", "中性")
+        trend_dir = trend.get("trend", "未知")
+
+        if sentiment == "积极" or trend_dir == "上涨":
+            return {"momentum": 0.03, "valuation": -0.01, "volatility": -0.01}
+        if sentiment == "消极" or trend_dir == "下跌":
+            return {"momentum": -0.02, "valuation": 0.02, "volatility": 0.03}
+        return {"momentum": 0.0, "valuation": 0.0, "volatility": 0.0}
+
+    def _run_groupchat_consensus(
+        self,
+        selected_candidates: List[Dict[str, Any]],
+        risk_preference: str,
+        investment_horizon: str,
+        market_sentiment: Optional[Dict[str, Any]],
+    ) -> str:
+        """使用AutoGen GroupChat生成多代理共识意见。"""
+        if not self.llm_config:
+            return "未启用共识分析：缺少llm_config。"
+
+        try:
+            user_proxy = autogen.UserProxyAgent(
+                name="ChiefPM",
+                human_input_mode="NEVER",
+                max_consecutive_auto_reply=1,
+                code_execution_config=False,
+            )
+            quant_analyst = autogen.AssistantAgent(
+                name="QuantAnalyst",
+                llm_config=self.llm_config,
+                system_message="你是量化分析师，重点评估因子有效性、风险收益比和组合分散度。",
+            )
+            fundamental_analyst = autogen.AssistantAgent(
+                name="FundamentalAnalyst",
+                llm_config=self.llm_config,
+                system_message="你是基本面分析师，重点关注估值、盈利质量与增长可持续性。",
+            )
+            risk_manager = autogen.AssistantAgent(
+                name="RiskManager",
+                llm_config=self.llm_config,
+                system_message="你是风控经理，重点评估波动、回撤风险与行业集中度，给出约束建议。",
+            )
+
+            groupchat = autogen.GroupChat(
+                agents=[user_proxy, quant_analyst, fundamental_analyst, risk_manager],
+                messages=[],
+                max_round=8,
+                speaker_selection_method="round_robin",
+            )
+            manager = autogen.GroupChatManager(groupchat=groupchat, llm_config=self.llm_config)
+
+            compact_candidates = []
+            for c in selected_candidates:
+                compact_candidates.append(
+                    {
+                        "symbol": c["symbol"],
+                        "name": c["name"],
+                        "industry": c["industry"],
+                        "score": round(c["score"], 4),
+                        "factors": {k: round(v, 4) for k, v in c["factors"].items()},
+                    }
+                )
+
+            prompt = (
+                f"请对以下选股结果做多代理共识评审，并输出最终结论：\n"
+                f"- 风险偏好: {risk_preference}\n"
+                f"- 投资期限: {investment_horizon}\n"
+                f"- 市场情绪: {json.dumps(market_sentiment, ensure_ascii=False) if market_sentiment else '未知'}\n"
+                f"- 候选池(已按分数排序):\n{json.dumps(compact_candidates, ensure_ascii=False, indent=2)}\n\n"
+                "请给出：\n"
+                "1. 最终前3只核心标的及理由\n"
+                "2. 组合层面的主要风险点\n"
+                "3. 仓位与再平衡建议（简要）\n"
+                "结尾请用“共识结论：”开头给出一句话总结。"
+            )
+
+            user_proxy.initiate_chat(manager, message=prompt, clear_history=True)
+
+            if manager.name in user_proxy.chat_messages and user_proxy.chat_messages[manager.name]:
+                return user_proxy.chat_messages[manager.name][-1].get("content", "")
+            if groupchat.messages:
+                return groupchat.messages[-1].get("content", "")
+            return "共识分析已执行，但未捕获到有效输出。"
+        except Exception as e:
+            return f"共识分析执行失败: {e}"
+
+    def select_stocks(
+        self,
+        symbols: List[str],
+        top_n: int = 5,
+        risk_preference: str = "中等",
+        investment_horizon: str = "长期",
+        max_per_industry: int = 2,
+        use_consensus: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        多因子智能选股。
+        """
+        unique_symbols = []
+        seen = set()
+        for s in symbols:
+            symbol = str(s).strip()
+            if symbol and symbol not in seen:
+                seen.add(symbol)
+                unique_symbols.append(symbol)
+
+        metrics = []
+        for symbol in unique_symbols:
+            m = self._collect_symbol_metrics(symbol)
+            if m:
+                metrics.append(m)
+
+        if not metrics:
+            return {
+                "error": "没有可用的候选股票数据，请检查候选池或稍后重试。",
+                "ranked_candidates": [],
+                "selected_symbols": [],
+            }
+
+        # 组装因子原始值
+        momentum_values = [
+            0.7 * m["raw_metrics"]["momentum_raw"] + 0.3 * m["raw_metrics"]["trend_win_rate"]
+            if np.isfinite(m["raw_metrics"]["momentum_raw"]) or np.isfinite(m["raw_metrics"]["trend_win_rate"])
+            else np.nan
+            for m in metrics
+        ]
+        valuation_values = [m["raw_metrics"]["valuation_raw"] for m in metrics]
+        volatility_values = [m["raw_metrics"]["volatility_raw"] for m in metrics]
+        liquidity_values = [m["raw_metrics"]["liquidity_raw"] for m in metrics]
+        quality_values = [m["raw_metrics"]["quality_raw"] for m in metrics]
+
+        # 归一化（估值、波动为逆向因子）
+        momentum_scores = self._normalize(momentum_values, reverse=False)
+        valuation_scores = self._normalize(valuation_values, reverse=True)
+        volatility_scores = self._normalize(volatility_values, reverse=True)
+        liquidity_scores = self._normalize(liquidity_values, reverse=False)
+        quality_scores = self._normalize(quality_values, reverse=False)
+
+        weights = self._build_final_weights(risk_preference, investment_horizon)
+        market_sentiment = cn_news_utils.get_stock_market_sentiment()
+        regime_bias = self._market_regime_bias(market_sentiment)
+
+        ranked_candidates = []
+        for idx, m in enumerate(metrics):
+            factors = {
+                "quality": quality_scores[idx],
+                "valuation": valuation_scores[idx],
+                "momentum": momentum_scores[idx],
+                "volatility": volatility_scores[idx],
+                "liquidity": liquidity_scores[idx],
+            }
+            base_score = sum(weights[k] * factors[k] for k in factors)
+            # 轻量市场偏置，增强策略“环境自适应”能力
+            adjusted_score = (
+                base_score
+                + regime_bias["momentum"] * factors["momentum"]
+                + regime_bias["valuation"] * factors["valuation"]
+                + regime_bias["volatility"] * factors["volatility"]
+            )
+            final_score = float(np.clip(adjusted_score, 0.0, 1.0))
+
+            ranked_candidates.append(
+                {
+                    "symbol": m["symbol"],
+                    "name": m["name"],
+                    "industry": m["industry"],
+                    "score": final_score,
+                    "factors": factors,
+                    "raw_metrics": m["raw_metrics"],
+                }
+            )
+
+        ranked_candidates.sort(key=lambda x: x["score"], reverse=True)
+
+        # 行业分散约束
+        selected = []
+        industry_counts: Dict[str, int] = {}
+        for candidate in ranked_candidates:
+            if len(selected) >= top_n:
+                break
+            industry = candidate["industry"] or "未知"
+            if max_per_industry > 0 and industry_counts.get(industry, 0) >= max_per_industry:
+                continue
+            selected.append(candidate)
+            industry_counts[industry] = industry_counts.get(industry, 0) + 1
+
+        # 若约束过强导致数量不足，则补齐
+        if len(selected) < top_n:
+            selected_symbols = {s["symbol"] for s in selected}
+            for candidate in ranked_candidates:
+                if len(selected) >= top_n:
+                    break
+                if candidate["symbol"] in selected_symbols:
+                    continue
+                selected.append(candidate)
+                selected_symbols.add(candidate["symbol"])
+                industry = candidate["industry"] or "未知"
+                industry_counts[industry] = industry_counts.get(industry, 0) + 1
+
+        result: Dict[str, Any] = {
+            "strategy": "multi_factor_v1",
+            "weights": weights,
+            "market_bias": regime_bias,
+            "ranked_candidates": ranked_candidates,
+            "selected_candidates": selected,
+            "selected_symbols": [c["symbol"] for c in selected],
+            "industry_distribution": industry_counts,
+        }
+
+        if use_consensus:
+            result["consensus"] = self._run_groupchat_consensus(
+                selected_candidates=selected,
+                risk_preference=risk_preference,
+                investment_horizon=investment_horizon,
+                market_sentiment=market_sentiment if isinstance(market_sentiment, dict) else None,
+            )
+
+        return result
+
+    @staticmethod
+    def format_selection_report(result: Dict[str, Any], top_show: int = 10) -> str:
+        """格式化选股结果为可读文本。"""
+        if "error" in result:
+            return f"选股失败: {result['error']}"
+
+        lines = []
+        lines.append("# 智能选股报告")
+        lines.append("")
+        lines.append(f"- 策略版本: {result.get('strategy', 'unknown')}")
+        lines.append(f"- 最终入选: {', '.join(result.get('selected_symbols', []))}")
+        lines.append(f"- 行业分布: {json.dumps(result.get('industry_distribution', {}), ensure_ascii=False)}")
+        lines.append("")
+        lines.append("## 因子权重")
+        for k, v in result.get("weights", {}).items():
+            lines.append(f"- {k}: {v:.2%}")
+        lines.append("")
+        lines.append("## 候选排名")
+
+        ranked = result.get("ranked_candidates", [])[:top_show]
+        for i, c in enumerate(ranked, 1):
+            lines.append(
+                f"{i}. {c['symbol']} {c['name']} | 行业:{c['industry']} | "
+                f"总分:{c['score']:.4f} | "
+                f"动量:{c['factors']['momentum']:.3f} 估值:{c['factors']['valuation']:.3f} "
+                f"质量:{c['factors']['quality']:.3f} 波动:{c['factors']['volatility']:.3f} "
+                f"流动性:{c['factors']['liquidity']:.3f}"
+            )
+
+        if result.get("consensus"):
+            lines.append("")
+            lines.append("## AutoGen 多代理共识")
+            lines.append(str(result["consensus"]))
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def export_selection_report(result: Dict[str, Any], fmt: str = "markdown", output_file: Optional[str] = None) -> str:
+        """导出选股报告。"""
+        content = StockSelectorAgent.format_selection_report(result)
+        if fmt == "html":
+            content = (
+                "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+                "<title>智能选股报告</title></head><body><pre>"
+                + content.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                + "</pre></body></html>"
+            )
+        elif fmt == "text":
+            # markdown本身已可读，这里保持同样内容
+            pass
+
+        if output_file:
+            if fmt == "html" and not output_file.endswith((".html", ".htm")):
+                output_file += ".html"
+            elif fmt == "text" and not output_file.endswith(".txt"):
+                output_file += ".txt"
+            elif fmt == "markdown" and not output_file.endswith((".md", ".markdown")):
+                output_file += ".md"
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(content)
+            return output_file
+        return content

--- a/deepseek_finrobot/cli.py
+++ b/deepseek_finrobot/cli.py
@@ -7,7 +7,16 @@ import sys
 import os
 import json
 from typing import Dict, Any, List, Optional
-from .agents import MarketForecasterAgent, FinancialReportAgent, NewsAnalysisAgent, IndustryAnalysisAgent, PortfolioManagerAgent, TechnicalAnalysisAgent
+from .agents import (
+    MarketForecasterAgent,
+    FinancialReportAgent,
+    NewsAnalysisAgent,
+    IndustryAnalysisAgent,
+    PortfolioManagerAgent,
+    TechnicalAnalysisAgent,
+    StockSelectorAgent,
+)
+from .data_source import akshare_utils
 from .utils import get_current_date, get_deepseek_config, register_keys_from_json
 
 def load_config() -> Dict[str, Any]:
@@ -328,6 +337,93 @@ def technical_analyze(args):
             analyst.export_analysis(analysis, format=args.format, output_file=output_file)
             print(f"\n分析结果已导出到: {output_file}")
 
+def select_stocks(args):
+    """
+    智能选股：多因子评分 + 可选多代理共识
+
+    Args:
+        args: 命令行参数
+    """
+    llm_config = load_config()
+    selector = StockSelectorAgent(llm_config=llm_config)
+
+    candidate_symbols: List[str] = []
+
+    # 1) 手动传入股票池
+    if args.stocks:
+        candidate_symbols.extend([s.strip() for s in args.stocks.split(",") if s.strip()])
+
+    # 2) 行业代码扩展股票池
+    if args.industry_code:
+        industry_df = akshare_utils.get_stock_industry_constituents(args.industry_code)
+        if not industry_df.empty and "代码" in industry_df.columns:
+            candidate_symbols.extend(industry_df["代码"].astype(str).tolist())
+        else:
+            print(f"警告: 未能通过行业代码获取成分股: {args.industry_code}")
+
+    # 3) 行业名称扩展股票池（先查行业列表，再获取成分股）
+    if args.industry_name:
+        industry_list = akshare_utils.get_stock_industry_list()
+        matched_code = None
+        if not industry_list.empty and "板块名称" in industry_list.columns and "板块代码" in industry_list.columns:
+            for _, row in industry_list.iterrows():
+                if str(row["板块名称"]).strip() == args.industry_name:
+                    matched_code = str(row["板块代码"]).strip()
+                    break
+        if matched_code:
+            industry_df = akshare_utils.get_stock_industry_constituents(matched_code)
+            if not industry_df.empty and "代码" in industry_df.columns:
+                candidate_symbols.extend(industry_df["代码"].astype(str).tolist())
+            else:
+                print(f"警告: 行业名称 {args.industry_name} 对应行业代码 {matched_code}，但未获取到成分股。")
+        else:
+            print(f"警告: 未找到行业名称: {args.industry_name}")
+
+    # 4) 概念代码扩展股票池
+    if args.concept_code:
+        concept_df = akshare_utils.get_stock_concept_constituents(args.concept_code)
+        if not concept_df.empty:
+            code_col = "代码" if "代码" in concept_df.columns else ("股票代码" if "股票代码" in concept_df.columns else None)
+            if code_col:
+                candidate_symbols.extend(concept_df[code_col].astype(str).tolist())
+            else:
+                print(f"警告: 概念成分股数据缺少代码列: {args.concept_code}")
+        else:
+            print(f"警告: 未能通过概念代码获取成分股: {args.concept_code}")
+
+    # 去重
+    unique_candidates = []
+    seen = set()
+    for s in candidate_symbols:
+        symbol = str(s).strip()
+        if symbol and symbol not in seen:
+            seen.add(symbol)
+            unique_candidates.append(symbol)
+
+    if not unique_candidates:
+        print("错误: 未获得候选股票池，请至少提供 --stocks 或行业/概念参数。")
+        sys.exit(1)
+
+    print(f"候选股票数: {len(unique_candidates)}，开始执行智能选股...")
+
+    result = selector.select_stocks(
+        symbols=unique_candidates,
+        top_n=args.top,
+        risk_preference=args.risk,
+        investment_horizon=args.horizon,
+        max_per_industry=args.max_per_industry,
+        use_consensus=args.consensus,
+    )
+
+    report = selector.format_selection_report(result, top_show=args.top_show)
+    print("\n===== 智能选股结果 =====\n")
+    print(report)
+
+    if args.export:
+        output_file = f"stock_selection_{get_current_date()}.{args.format}"
+        exported = selector.export_selection_report(result, fmt=args.format, output_file=output_file)
+        print(f"\n选股报告已导出到: {exported}")
+
 def main():
     """
     主函数
@@ -406,6 +502,22 @@ def main():
     technical_parser.add_argument("--export", action="store_true", help="导出分析结果")
     technical_parser.add_argument("--format", choices=["markdown", "html", "text"], default="markdown", help="导出格式")
     technical_parser.set_defaults(func=technical_analyze)
+
+    # 智能选股
+    select_parser = subparsers.add_parser("select", help="智能选股（多因子评分 + 可选AutoGen多代理共识）")
+    select_parser.add_argument("--stocks", help="手动指定候选股票池，格式：000001,600519,...")
+    select_parser.add_argument("--industry-code", help="行业代码（如 BK0475），用于自动扩展候选池")
+    select_parser.add_argument("--industry-name", help="行业名称（如 银行），用于自动扩展候选池")
+    select_parser.add_argument("--concept-code", help="概念代码（如 BK0815），用于自动扩展候选池")
+    select_parser.add_argument("--top", type=int, default=5, help="最终入选股票数量")
+    select_parser.add_argument("--top-show", type=int, default=10, help="报告中展示的候选排名数量")
+    select_parser.add_argument("--risk", choices=["保守", "中等", "激进"], default="中等", help="风险偏好")
+    select_parser.add_argument("--horizon", choices=["短期", "中期", "长期"], default="长期", help="投资期限")
+    select_parser.add_argument("--max-per-industry", type=int, default=2, help="单一行业最多入选数量（0表示不限制）")
+    select_parser.add_argument("--consensus", action="store_true", help="启用AutoGen GroupChat多代理共识分析")
+    select_parser.add_argument("--export", action="store_true", help="导出选股报告")
+    select_parser.add_argument("--format", choices=["markdown", "html", "text"], default="markdown", help="导出格式")
+    select_parser.set_defaults(func=select_stocks)
     
     args = parser.parse_args()
     

--- a/deepseek_finrobot/data_source/akshare_utils.py
+++ b/deepseek_finrobot/data_source/akshare_utils.py
@@ -25,6 +25,7 @@ def get_stock_info(symbol: str) -> Dict[str, Any]:
     try:
         try:
             # region agent log
+            os.makedirs("/opt/cursor/logs", exist_ok=True)
             open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
                 json.dumps(
                     {
@@ -59,6 +60,7 @@ def get_stock_info(symbol: str) -> Dict[str, Any]:
             realtime_data = ak.stock_zh_a_spot_em()
             try:
                 # region agent log
+                os.makedirs("/opt/cursor/logs", exist_ok=True)
                 open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
                     json.dumps(
                         {
@@ -558,6 +560,7 @@ def get_stock_industry_constituents(industry_code: str) -> pd.DataFrame:
         nan_pe_count = int(df['市盈率'].isna().sum()) if '市盈率' in df.columns else 0
         try:
             # region agent log
+            os.makedirs("/opt/cursor/logs", exist_ok=True)
             open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
                 json.dumps(
                     {
@@ -586,6 +589,7 @@ def get_stock_industry_constituents(industry_code: str) -> pd.DataFrame:
                     df.at[idx, '市盈率'] = 0.0
         try:
             # region agent log
+            os.makedirs("/opt/cursor/logs", exist_ok=True)
             open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
                 json.dumps(
                     {

--- a/deepseek_finrobot/data_source/akshare_utils.py
+++ b/deepseek_finrobot/data_source/akshare_utils.py
@@ -8,8 +8,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from typing import Dict, List, Optional, Union, Any
 import datetime
-import json
-import os
 import time
 import pypinyin
 
@@ -57,11 +55,19 @@ def get_stock_realtime_snapshot(ttl_seconds: int = 30, force_refresh: bool = Fal
     ):
         return cached
 
-    snapshot = _call_with_retry(ak.stock_zh_a_spot_em, max_retries=2, base_delay=0.8)
-    if isinstance(snapshot, pd.DataFrame) and not snapshot.empty:
-        _SPOT_CACHE["timestamp"] = now
-        _SPOT_CACHE["data"] = snapshot
-    return snapshot
+    try:
+        snapshot = _call_with_retry(ak.stock_zh_a_spot_em, max_retries=2, base_delay=0.8)
+        if isinstance(snapshot, pd.DataFrame) and not snapshot.empty:
+            _SPOT_CACHE["timestamp"] = now
+            _SPOT_CACHE["data"] = snapshot
+        return snapshot
+    except Exception as e:
+        # 网络抖动时，优先返回缓存，避免调用方整体失败
+        if isinstance(cached, pd.DataFrame) and not cached.empty:
+            print(f"获取实时快照失败，回退使用缓存数据: {e}")
+            return cached
+        print(f"获取实时快照失败且无缓存可用: {e}")
+        return pd.DataFrame()
 
 
 def _normalize_industry_columns(df: pd.DataFrame) -> pd.DataFrame:
@@ -104,26 +110,6 @@ def get_stock_info(symbol: str) -> Dict[str, Any]:
         股票信息字典
     """
     try:
-        try:
-            # region agent log
-            os.makedirs("/opt/cursor/logs", exist_ok=True)
-            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-                json.dumps(
-                    {
-                        "hypothesisId": "A",
-                        "location": "akshare_utils.py:24",
-                        "message": "get_stock_info_entry",
-                        "data": {"symbol": symbol},
-                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                    },
-                    ensure_ascii=False,
-                )
-                + "\n"
-            )
-            # endregion
-        except Exception:
-            pass
-
         # 获取股票基本信息
         stock_info = _call_with_retry(ak.stock_individual_info_em, max_retries=2, base_delay=0.8, symbol=symbol)
         
@@ -139,31 +125,15 @@ def get_stock_info(symbol: str) -> Dict[str, Any]:
         try:
             # 获取A股实时行情
             realtime_data = get_stock_realtime_snapshot(ttl_seconds=30)
-            try:
-                # region agent log
-                os.makedirs("/opt/cursor/logs", exist_ok=True)
-                open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-                    json.dumps(
-                        {
-                            "hypothesisId": "A",
-                            "location": "akshare_utils.py:39",
-                            "message": "stock_zh_a_spot_em_fetched",
-                            "data": {"symbol": symbol, "rows": int(len(realtime_data))},
-                            "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                        },
-                        ensure_ascii=False,
-                    )
-                    + "\n"
-                )
-                # endregion
-            except Exception:
-                pass
             
             # 只在调试时输出列名
             # print(f"实时行情数据列: {realtime_data.columns.tolist()}")
             
             # 过滤指定股票
-            realtime_data = realtime_data[realtime_data['代码'] == symbol]
+            if not realtime_data.empty and "代码" in realtime_data.columns:
+                realtime_data = realtime_data[realtime_data['代码'] == symbol]
+            else:
+                realtime_data = pd.DataFrame()
             
             if not realtime_data.empty:
                 # 安全获取最新价
@@ -227,12 +197,15 @@ def get_stock_history(symbol: str, period: str = "daily",
             start_date = (datetime.datetime.now() - datetime.timedelta(days=365)).strftime("%Y%m%d")
             
         # 调用AKShare获取A股历史数据
-        df = ak.stock_zh_a_hist(
-            symbol=symbol, 
-            period=period, 
-            start_date=start_date, 
-            end_date=end_date, 
-            adjust=adjust
+        df = _call_with_retry(
+            ak.stock_zh_a_hist,
+            max_retries=1,
+            base_delay=0.6,
+            symbol=symbol,
+            period=period,
+            start_date=start_date,
+            end_date=end_date,
+            adjust=adjust,
         )
         
         if df.empty:
@@ -274,10 +247,14 @@ def get_stock_realtime_quote(symbol: str) -> Dict[str, Any]:
         股票实时行情字典
     """
     try:
-        # 获取A股实时行情
-        df = ak.stock_zh_a_spot_em()
+        # 获取A股实时行情（使用带缓存与重试的快照）
+        df = get_stock_realtime_snapshot(ttl_seconds=30)
+        if df.empty:
+            return {"error": "实时行情数据不可用"}
         
         # 过滤指定股票
+        if '代码' not in df.columns:
+            return {"error": "实时行情数据缺少代码列"}
         df = df[df['代码'] == symbol]
         
         if df.empty:
@@ -335,7 +312,12 @@ def get_stock_financial_indicator(symbol: str) -> pd.DataFrame:
     """
     try:
         # 获取财务指标
-        df = ak.stock_financial_analysis_indicator(symbol=symbol)
+        df = _call_with_retry(
+            ak.stock_financial_analysis_indicator,
+            max_retries=1,
+            base_delay=0.6,
+            symbol=symbol,
+        )
         
         return df
     except Exception as e:
@@ -655,26 +637,6 @@ def get_stock_industry_constituents(industry_code: str) -> pd.DataFrame:
     df = _normalize_constituents(df)
 
     # 如果市盈率列为空，尝试获取个股数据
-    nan_pe_count = int(df['市盈率'].isna().sum()) if '市盈率' in df.columns else 0
-    try:
-        # region agent log
-        os.makedirs("/opt/cursor/logs", exist_ok=True)
-        open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-            json.dumps(
-                {
-                    "hypothesisId": "C",
-                    "location": "akshare_utils.py:520",
-                    "message": "industry_constituents_pre_pe_backfill",
-                    "data": {"industry_code": industry_code, "rows": int(len(df)), "nan_pe_count": nan_pe_count},
-                    "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                },
-                ensure_ascii=False,
-            )
-            + "\n"
-        )
-        # endregion
-    except Exception:
-        pass
     indicator_calls = 0
     if '市盈率' in df.columns and df['市盈率'].isna().any():
         missing_pe_idx = df[df['市盈率'].isna()].index.tolist()
@@ -693,25 +655,8 @@ def get_stock_industry_constituents(industry_code: str) -> pd.DataFrame:
             df.loc[missing_pe_idx[max_backfill_calls:], '市盈率'] = df.loc[
                 missing_pe_idx[max_backfill_calls:], '市盈率'
             ].fillna(0.0)
-    try:
-        # region agent log
-        os.makedirs("/opt/cursor/logs", exist_ok=True)
-        open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-            json.dumps(
-                {
-                    "hypothesisId": "C",
-                    "location": "akshare_utils.py:531",
-                    "message": "industry_constituents_post_pe_backfill",
-                    "data": {"industry_code": industry_code, "indicator_calls": indicator_calls},
-                    "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                },
-                ensure_ascii=False,
-            )
-            + "\n"
-        )
-        # endregion
-    except Exception:
-        pass
+    if indicator_calls > 0:
+        print(f"行业 {industry_code} 成分股市盈率补齐调用次数: {indicator_calls}")
 
     # 选择需要的列并填充缺省值
     df = df[list(required_columns.keys())]

--- a/deepseek_finrobot/data_source/akshare_utils.py
+++ b/deepseek_finrobot/data_source/akshare_utils.py
@@ -8,6 +8,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from typing import Dict, List, Optional, Union, Any
 import datetime
+import json
 import os
 import pypinyin
 
@@ -22,6 +23,25 @@ def get_stock_info(symbol: str) -> Dict[str, Any]:
         股票信息字典
     """
     try:
+        try:
+            # region agent log
+            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+                json.dumps(
+                    {
+                        "hypothesisId": "A",
+                        "location": "akshare_utils.py:24",
+                        "message": "get_stock_info_entry",
+                        "data": {"symbol": symbol},
+                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+            # endregion
+        except Exception:
+            pass
+
         # 获取股票基本信息
         stock_info = ak.stock_individual_info_em(symbol=symbol)
         
@@ -37,6 +57,24 @@ def get_stock_info(symbol: str) -> Dict[str, Any]:
         try:
             # 获取A股实时行情
             realtime_data = ak.stock_zh_a_spot_em()
+            try:
+                # region agent log
+                open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+                    json.dumps(
+                        {
+                            "hypothesisId": "A",
+                            "location": "akshare_utils.py:39",
+                            "message": "stock_zh_a_spot_em_fetched",
+                            "data": {"symbol": symbol, "rows": int(len(realtime_data))},
+                            "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+                # endregion
+            except Exception:
+                pass
             
             # 只在调试时输出列名
             # print(f"实时行情数据列: {realtime_data.columns.tolist()}")
@@ -517,14 +555,53 @@ def get_stock_industry_constituents(industry_code: str) -> pd.DataFrame:
             df[col] = df[col].astype(dtype)
             
         # 如果市盈率列为空，尝试获取个股数据
+        nan_pe_count = int(df['市盈率'].isna().sum()) if '市盈率' in df.columns else 0
+        try:
+            # region agent log
+            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+                json.dumps(
+                    {
+                        "hypothesisId": "C",
+                        "location": "akshare_utils.py:520",
+                        "message": "industry_constituents_pre_pe_backfill",
+                        "data": {"industry_code": industry_code, "rows": int(len(df)), "nan_pe_count": nan_pe_count},
+                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+            # endregion
+        except Exception:
+            pass
+        indicator_calls = 0
         if '市盈率' in df.columns and df['市盈率'].isna().any():
             for idx, row in df.iterrows():
                 try:
+                    indicator_calls += 1
                     stock_info = ak.stock_a_lg_indicator(symbol=row['代码'])
                     if not stock_info.empty and '市盈率' in stock_info.columns:
                         df.at[idx, '市盈率'] = stock_info['市盈率'].iloc[0]
                 except:
                     df.at[idx, '市盈率'] = 0.0
+        try:
+            # region agent log
+            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+                json.dumps(
+                    {
+                        "hypothesisId": "C",
+                        "location": "akshare_utils.py:531",
+                        "message": "industry_constituents_post_pe_backfill",
+                        "data": {"industry_code": industry_code, "indicator_calls": indicator_calls},
+                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+            # endregion
+        except Exception:
+            pass
                     
         # 选择需要的列
         df = df[list(required_columns.keys())]

--- a/deepseek_finrobot/data_source/akshare_utils.py
+++ b/deepseek_finrobot/data_source/akshare_utils.py
@@ -10,7 +10,88 @@ from typing import Dict, List, Optional, Union, Any
 import datetime
 import json
 import os
+import time
 import pypinyin
+
+
+_SPOT_CACHE: Dict[str, Any] = {"timestamp": 0.0, "data": None}
+
+
+def _is_retryable_network_error(error: Exception) -> bool:
+    text = str(error)
+    retry_signals = (
+        "RemoteDisconnected",
+        "Connection aborted",
+        "Read timed out",
+        "ConnectTimeout",
+        "ConnectionResetError",
+        "Max retries exceeded",
+    )
+    return any(signal in text for signal in retry_signals)
+
+
+def _call_with_retry(func, max_retries: int = 2, base_delay: float = 0.8, **kwargs):
+    last_error = None
+    for attempt in range(max_retries + 1):
+        try:
+            return func(**kwargs)
+        except Exception as error:
+            last_error = error
+            if attempt >= max_retries or not _is_retryable_network_error(error):
+                raise
+            time.sleep(base_delay * (2**attempt))
+    raise last_error
+
+
+def get_stock_realtime_snapshot(ttl_seconds: int = 30, force_refresh: bool = False) -> pd.DataFrame:
+    """
+    获取A股实时快照（带短TTL缓存），避免高频重复请求导致网络抖动。
+    """
+    now = time.time()
+    cached = _SPOT_CACHE.get("data")
+    if (
+        not force_refresh
+        and isinstance(cached, pd.DataFrame)
+        and not cached.empty
+        and (now - float(_SPOT_CACHE.get("timestamp", 0.0))) < ttl_seconds
+    ):
+        return cached
+
+    snapshot = _call_with_retry(ak.stock_zh_a_spot_em, max_retries=2, base_delay=0.8)
+    if isinstance(snapshot, pd.DataFrame) and not snapshot.empty:
+        _SPOT_CACHE["timestamp"] = now
+        _SPOT_CACHE["data"] = snapshot
+    return snapshot
+
+
+def _normalize_industry_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    统一行业列表列名，确保至少包含：板块名称、板块代码。
+    """
+    if df is None or df.empty:
+        return df
+
+    rename_map: Dict[str, str] = {}
+    if "板块名称" not in df.columns:
+        for candidate in ["板块名", "名称", "板块"]:
+            if candidate in df.columns:
+                rename_map[candidate] = "板块名称"
+                break
+    if "板块代码" not in df.columns:
+        for candidate in ["label", "代码", "板块ID", "股票代码"]:
+            if candidate in df.columns:
+                rename_map[candidate] = "板块代码"
+                break
+
+    if rename_map:
+        df = df.rename(columns=rename_map)
+
+    if "板块名称" not in df.columns:
+        df["板块名称"] = "未知行业"
+    if "板块代码" not in df.columns:
+        df["板块代码"] = ""
+
+    return df
 
 def get_stock_info(symbol: str) -> Dict[str, Any]:
     """
@@ -44,7 +125,7 @@ def get_stock_info(symbol: str) -> Dict[str, Any]:
             pass
 
         # 获取股票基本信息
-        stock_info = ak.stock_individual_info_em(symbol=symbol)
+        stock_info = _call_with_retry(ak.stock_individual_info_em, max_retries=2, base_delay=0.8, symbol=symbol)
         
         if stock_info.empty:
             return {"error": "未找到股票信息"}
@@ -57,7 +138,7 @@ def get_stock_info(symbol: str) -> Dict[str, Any]:
         # 补充获取实时行情数据
         try:
             # 获取A股实时行情
-            realtime_data = ak.stock_zh_a_spot_em()
+            realtime_data = get_stock_realtime_snapshot(ttl_seconds=30)
             try:
                 # region agent log
                 os.makedirs("/opt/cursor/logs", exist_ok=True)
@@ -457,15 +538,10 @@ def get_stock_industry_list() -> pd.DataFrame:
     """
     try:
         # 获取行业列表
-        df = ak.stock_board_industry_name_em()
+        df = _call_with_retry(ak.stock_board_industry_name_em, max_retries=2, base_delay=0.8)
         
         # 确保列名一致性
-        if '板块名称' not in df.columns and '板块名' in df.columns:
-            df = df.rename(columns={'板块名': '板块名称'})
-        if '板块名称' not in df.columns and '名称' in df.columns:
-            df = df.rename(columns={'名称': '板块名称'})
-        if '板块代码' not in df.columns and '代码' in df.columns:
-            df = df.rename(columns={'代码': '板块代码'})
+        df = _normalize_industry_columns(df)
             
         print(f"成功获取行业列表，共找到 {len(df)} 个行业")
         return df
@@ -475,11 +551,10 @@ def get_stock_industry_list() -> pd.DataFrame:
         try:
             # 尝试使用板块行情接口
             print("尝试使用替代接口获取行业列表...")
-            df = ak.stock_sector_spot(indicator="行业")
+            df = _call_with_retry(ak.stock_sector_spot, max_retries=2, base_delay=0.8, indicator="行业")
             
             # 重命名列以匹配原来的接口
-            if '板块名称' not in df.columns and '板块' in df.columns:
-                df = df.rename(columns={'板块': '板块名称'})
+            df = _normalize_industry_columns(df)
                 
             print(f"成功使用替代接口获取行业列表，共找到 {len(df)} 个行业")
             return df
@@ -530,7 +605,7 @@ def get_stock_industry_constituents(industry_code: str) -> pd.DataFrame:
     """
     try:
         # 使用东方财富行业成分股接口
-        df = ak.stock_board_industry_cons_em(symbol=industry_code)
+        df = _call_with_retry(ak.stock_board_industry_cons_em, max_retries=2, base_delay=0.8, symbol=industry_code)
         
         # 确保必要的列存在
         required_columns = {
@@ -579,14 +654,22 @@ def get_stock_industry_constituents(industry_code: str) -> pd.DataFrame:
             pass
         indicator_calls = 0
         if '市盈率' in df.columns and df['市盈率'].isna().any():
-            for idx, row in df.iterrows():
+            missing_pe_idx = df[df['市盈率'].isna()].index.tolist()
+            # 限制补齐请求数量，避免大行业触发N+1网络风暴
+            max_backfill_calls = 8
+            for idx in missing_pe_idx[:max_backfill_calls]:
                 try:
                     indicator_calls += 1
-                    stock_info = ak.stock_a_lg_indicator(symbol=row['代码'])
+                    stock_code = str(df.at[idx, '代码'])
+                    stock_info = _call_with_retry(ak.stock_a_lg_indicator, max_retries=1, base_delay=0.6, symbol=stock_code)
                     if not stock_info.empty and '市盈率' in stock_info.columns:
                         df.at[idx, '市盈率'] = stock_info['市盈率'].iloc[0]
                 except:
                     df.at[idx, '市盈率'] = 0.0
+            if len(missing_pe_idx) > max_backfill_calls:
+                df.loc[missing_pe_idx[max_backfill_calls:], '市盈率'] = df.loc[
+                    missing_pe_idx[max_backfill_calls:], '市盈率'
+                ].fillna(0.0)
         try:
             # region agent log
             os.makedirs("/opt/cursor/logs", exist_ok=True)

--- a/deepseek_finrobot/data_source/akshare_utils.py
+++ b/deepseek_finrobot/data_source/akshare_utils.py
@@ -603,100 +603,124 @@ def get_stock_industry_constituents(industry_code: str) -> pd.DataFrame:
     :param industry_code: 行业代码
     :return: 成分股数据
     """
-    try:
-        # 使用东方财富行业成分股接口
-        df = _call_with_retry(ak.stock_board_industry_cons_em, max_retries=2, base_delay=0.8, symbol=industry_code)
-        
-        # 确保必要的列存在
-        required_columns = {
-            '代码': str,
-            '名称': str,
-            '最新价': float,
-            '涨跌幅': float,
-            '市盈率': float,
-            '市净率': float
-        }
-        
-        # 重命名列（如果需要）
+    required_columns = {
+        '代码': str,
+        '名称': str,
+        '最新价': float,
+        '涨跌幅': float,
+        '市盈率': float,
+        '市净率': float
+    }
+
+    def _normalize_constituents(df: pd.DataFrame) -> pd.DataFrame:
         rename_map = {
             '股票代码': '代码',
             '股票名称': '名称',
-            '市盈率-动态': '市盈率'
+            '市盈率-动态': '市盈率',
+            'code': '代码',
+            'name': '名称',
+            'trade': '最新价',
+            'changepercent': '涨跌幅',
+            'per': '市盈率',
+            'pb': '市净率',
         }
         df = df.rename(columns=rename_map)
-        
-        # 添加缺失的列并设置默认值
+
         for col, dtype in required_columns.items():
             if col not in df.columns:
-                df[col] = dtype(0)
-            df[col] = df[col].astype(dtype)
-            
-        # 如果市盈率列为空，尝试获取个股数据
-        nan_pe_count = int(df['市盈率'].isna().sum()) if '市盈率' in df.columns else 0
-        try:
-            # region agent log
-            os.makedirs("/opt/cursor/logs", exist_ok=True)
-            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-                json.dumps(
-                    {
-                        "hypothesisId": "C",
-                        "location": "akshare_utils.py:520",
-                        "message": "industry_constituents_pre_pe_backfill",
-                        "data": {"industry_code": industry_code, "rows": int(len(df)), "nan_pe_count": nan_pe_count},
-                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                    },
-                    ensure_ascii=False,
-                )
-                + "\n"
-            )
-            # endregion
-        except Exception:
-            pass
-        indicator_calls = 0
-        if '市盈率' in df.columns and df['市盈率'].isna().any():
-            missing_pe_idx = df[df['市盈率'].isna()].index.tolist()
-            # 限制补齐请求数量，避免大行业触发N+1网络风暴
-            max_backfill_calls = 8
-            for idx in missing_pe_idx[:max_backfill_calls]:
-                try:
-                    indicator_calls += 1
-                    stock_code = str(df.at[idx, '代码'])
-                    stock_info = _call_with_retry(ak.stock_a_lg_indicator, max_retries=1, base_delay=0.6, symbol=stock_code)
-                    if not stock_info.empty and '市盈率' in stock_info.columns:
-                        df.at[idx, '市盈率'] = stock_info['市盈率'].iloc[0]
-                except:
-                    df.at[idx, '市盈率'] = 0.0
-            if len(missing_pe_idx) > max_backfill_calls:
-                df.loc[missing_pe_idx[max_backfill_calls:], '市盈率'] = df.loc[
-                    missing_pe_idx[max_backfill_calls:], '市盈率'
-                ].fillna(0.0)
-        try:
-            # region agent log
-            os.makedirs("/opt/cursor/logs", exist_ok=True)
-            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-                json.dumps(
-                    {
-                        "hypothesisId": "C",
-                        "location": "akshare_utils.py:531",
-                        "message": "industry_constituents_post_pe_backfill",
-                        "data": {"industry_code": industry_code, "indicator_calls": indicator_calls},
-                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                    },
-                    ensure_ascii=False,
-                )
-                + "\n"
-            )
-            # endregion
-        except Exception:
-            pass
-                    
-        # 选择需要的列
-        df = df[list(required_columns.keys())]
+                df[col] = np.nan if dtype is float else ""
+            if dtype is float:
+                df[col] = pd.to_numeric(df[col], errors='coerce')
+            else:
+                df[col] = df[col].astype(str)
+
         return df
-    except Exception as e:
-        print(f"获取行业成分股失败: {e}")
-        # 返回空DataFrame，但包含所需的列
-        return pd.DataFrame(columns=list(required_columns.keys()))
+
+    try:
+        # 使用东方财富行业成分股接口
+        df = _call_with_retry(ak.stock_board_industry_cons_em, max_retries=2, base_delay=0.8, symbol=industry_code)
+    except Exception as primary_e:
+        print(f"获取行业成分股失败: {primary_e}")
+        try:
+            # stock_sector_spot 返回的 hangye_* 标识可用 stock_sector_detail 获取成分股
+            if str(industry_code).startswith("hangye_"):
+                print("尝试使用 stock_sector_detail 作为行业成分股替代接口...")
+                df = _call_with_retry(ak.stock_sector_detail, max_retries=1, base_delay=0.6, sector=industry_code)
+            else:
+                raise
+        except Exception as fallback_e:
+            print(f"使用替代接口获取行业成分股失败: {fallback_e}")
+            return pd.DataFrame(columns=list(required_columns.keys()))
+
+    df = _normalize_constituents(df)
+
+    # 如果市盈率列为空，尝试获取个股数据
+    nan_pe_count = int(df['市盈率'].isna().sum()) if '市盈率' in df.columns else 0
+    try:
+        # region agent log
+        os.makedirs("/opt/cursor/logs", exist_ok=True)
+        open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+            json.dumps(
+                {
+                    "hypothesisId": "C",
+                    "location": "akshare_utils.py:520",
+                    "message": "industry_constituents_pre_pe_backfill",
+                    "data": {"industry_code": industry_code, "rows": int(len(df)), "nan_pe_count": nan_pe_count},
+                    "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        # endregion
+    except Exception:
+        pass
+    indicator_calls = 0
+    if '市盈率' in df.columns and df['市盈率'].isna().any():
+        missing_pe_idx = df[df['市盈率'].isna()].index.tolist()
+        # 限制补齐请求数量，避免大行业触发N+1网络风暴
+        max_backfill_calls = 8
+        for idx in missing_pe_idx[:max_backfill_calls]:
+            try:
+                indicator_calls += 1
+                stock_code = str(df.at[idx, '代码'])
+                stock_info = _call_with_retry(ak.stock_a_lg_indicator, max_retries=1, base_delay=0.6, symbol=stock_code)
+                if not stock_info.empty and '市盈率' in stock_info.columns:
+                    df.at[idx, '市盈率'] = stock_info['市盈率'].iloc[0]
+            except Exception:
+                df.at[idx, '市盈率'] = 0.0
+        if len(missing_pe_idx) > max_backfill_calls:
+            df.loc[missing_pe_idx[max_backfill_calls:], '市盈率'] = df.loc[
+                missing_pe_idx[max_backfill_calls:], '市盈率'
+            ].fillna(0.0)
+    try:
+        # region agent log
+        os.makedirs("/opt/cursor/logs", exist_ok=True)
+        open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+            json.dumps(
+                {
+                    "hypothesisId": "C",
+                    "location": "akshare_utils.py:531",
+                    "message": "industry_constituents_post_pe_backfill",
+                    "data": {"industry_code": industry_code, "indicator_calls": indicator_calls},
+                    "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        # endregion
+    except Exception:
+        pass
+
+    # 选择需要的列并填充缺省值
+    df = df[list(required_columns.keys())]
+    for col, dtype in required_columns.items():
+        if dtype is float:
+            df[col] = pd.to_numeric(df[col], errors='coerce').fillna(0.0)
+        else:
+            df[col] = df[col].fillna("").astype(str)
+    return df
 
 def get_stock_concept_constituents(concept_code: str) -> pd.DataFrame:
     """

--- a/deepseek_finrobot/data_source/cn_news_utils.py
+++ b/deepseek_finrobot/data_source/cn_news_utils.py
@@ -7,6 +7,7 @@ import pandas as pd
 from typing import Dict, List, Optional, Union, Any
 import datetime
 import json
+import os
 import re
 import requests
 from bs4 import BeautifulSoup
@@ -315,6 +316,7 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
     try:
         try:
             # region agent log
+            os.makedirs("/opt/cursor/logs", exist_ok=True)
             open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
                 json.dumps(
                     {
@@ -470,6 +472,7 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
                     continue
             try:
                 # region agent log
+                os.makedirs("/opt/cursor/logs", exist_ok=True)
                 open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
                     json.dumps(
                         {

--- a/deepseek_finrobot/data_source/cn_news_utils.py
+++ b/deepseek_finrobot/data_source/cn_news_utils.py
@@ -9,8 +9,38 @@ import datetime
 import json
 import os
 import re
+import time
 import requests
 from bs4 import BeautifulSoup
+
+
+_SENTIMENT_CACHE: Dict[str, Any] = {"timestamp": 0.0, "data": None}
+
+
+def _is_retryable_network_error(error: Exception) -> bool:
+    text = str(error)
+    retry_signals = (
+        "RemoteDisconnected",
+        "Connection aborted",
+        "Read timed out",
+        "ConnectTimeout",
+        "ConnectionResetError",
+        "Max retries exceeded",
+    )
+    return any(signal in text for signal in retry_signals)
+
+
+def _call_with_retry(func, max_retries: int = 2, base_delay: float = 0.8, **kwargs):
+    last_error = None
+    for attempt in range(max_retries + 1):
+        try:
+            return func(**kwargs)
+        except Exception as error:
+            last_error = error
+            if attempt >= max_retries or not _is_retryable_network_error(error):
+                raise
+            time.sleep(base_delay * (2**attempt))
+    raise last_error
 
 def get_financial_news(limit: int = 20) -> pd.DataFrame:
     """
@@ -314,6 +344,12 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
         股市情绪指标字典
     """
     try:
+        cache_ttl_seconds = 120
+        cached_data = _SENTIMENT_CACHE.get("data")
+        cached_ts = float(_SENTIMENT_CACHE.get("timestamp", 0.0))
+        if isinstance(cached_data, dict) and (time.time() - cached_ts) < cache_ttl_seconds:
+            return dict(cached_data)
+
         try:
             # region agent log
             os.makedirs("/opt/cursor/logs", exist_ok=True)
@@ -343,10 +379,10 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
             # 直接获取上证指数实时行情，避免日期索引问题
             try:
                 # 尝试使用新的API名称
-                df_sh_spot = ak.stock_zh_index_spot_sina()
+                df_sh_spot = _call_with_retry(ak.stock_zh_index_spot_sina, max_retries=1, base_delay=0.6)
             except AttributeError:
                 # 如果不存在，尝试旧的API名称 (兼容旧版本)
-                df_sh_spot = ak.stock_zh_index_spot()
+                df_sh_spot = _call_with_retry(ak.stock_zh_index_spot, max_retries=1, base_delay=0.6)
                 
             # 筛选上证指数
             df_sh_spot = df_sh_spot[df_sh_spot['名称'] == '上证指数']
@@ -373,10 +409,10 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
             try:
                 # 尝试使用新的API名称
                 try:
-                    df_hs300 = ak.stock_zh_index_spot_sina()
+                        df_hs300 = _call_with_retry(ak.stock_zh_index_spot_sina, max_retries=1, base_delay=0.6)
                 except AttributeError:
                     # 如果不存在，尝试旧的API名称
-                    df_hs300 = ak.stock_zh_index_spot()
+                        df_hs300 = _call_with_retry(ak.stock_zh_index_spot, max_retries=1, base_delay=0.6)
                     
                 df_hs300 = df_hs300[df_hs300['名称'] == '沪深300']
                 
@@ -413,7 +449,7 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
                     'sentiment': '中性'
                 }
         
-        # 获取市场资金流向数据 - 尝试多种可能的API
+        # 获取市场资金流向数据 - 优先稳定接口，减少无效尝试
         try:
             north_data = None
             api_found = False
@@ -421,44 +457,21 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
             north_api_failures = 0
             north_selected_api = None
             
-            # 尝试所有可能的北向资金API
+            # 优先已验证可用接口，避免在大量候选API中“试错风暴”
             possible_apis = [
-                # 尝试各种可能的函数名
-                ('stock_em_hsgt_north_net_flow_in_hist', {}),  
+                ("stock_hsgt_hist_em", {}),
+                ("stock_em_hsgt_north_net_flow_in_hist", {}),
                 ('stock_em_hsgt_north_net_flow_in', {}),
-                ('stock_em_hsgt_hist', {}),
-                ('stock_em_hsgt_capital_flow', {}),
-                ('stock_em_hsgt_board_flow_summary', {}),
-                ('stock_hsgt_fund_flow_summary', {}),
-                ('stock_hsgt_north_net_flow_in', {}),
-                ('stock_hsgt_north_acc_flow_in', {}),
-                ('stock_hsgt_summary', {}),
-                # 尝试获取沪深港通资金流向
-                ('stock_em_hsgt_hist_em', {'symbol': 'southbound'}),
-                ('stock_em_hsgt_fund_flow_summary', {}),
-                # 根据更新日志添加的新API名称
-                ('stock_hk_ggt_components_em', {}),
-                ('stock_hsgt_hist_em', {}),
-                ('stock_hsgt_board_sem', {}),
-                ('stock_hsgt_north_flow_em', {}),
-                ('stock_hsgt_south_flow_em', {}),
-                ('stock_hsgt_north_net_flow_em', {}),
-                ('stock_hsgt_south_net_flow_em', {}),
-                ('stock_hsgt_hold_stock_em', {}),
-                ('stock_hsgt_institution_statistics_em', {}),
-                ('stock_hsgt_stock_statistics_em', {}),
-                ('stock_hsgt_stock_statistics_hist_em', {}),
-                # 最简单的应急方案 - 从东财获取实时资金流数据
-                ('stock_fund_flow_individual_em', {})
+                ("stock_hsgt_north_net_flow_em", {}),
             ]
             
             for api_name, api_params in possible_apis:
-                north_api_attempts += 1
                 try:
                     api_func = getattr(ak, api_name, None)
                     if api_func:
+                        north_api_attempts += 1
                         print(f"尝试API: {api_name}")
-                        north_data = api_func(**api_params)
+                        north_data = _call_with_retry(api_func, max_retries=1, base_delay=0.6, **api_params)
                         if not north_data.empty:
                             api_found = True
                             north_selected_api = api_name
@@ -529,6 +542,8 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
                             flow_value = float(flow_value.replace(',', '').replace('亿', ''))
                         else:
                             flow_value = float(flow_value)
+                        if pd.isna(flow_value):
+                            raise ValueError("北向资金数值为NaN")
                             
                         result["north_flow"] = {
                             "date": str(north_data.iloc[-1][date_col]),
@@ -566,7 +581,7 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
         # 获取市场活跃度数据
         try:
             try:
-                df_activity = ak.stock_market_activity_legu()
+                df_activity = _call_with_retry(ak.stock_market_activity_legu, max_retries=1, base_delay=0.6)
                 if not df_activity.empty:
                     result["market_activity"] = df_activity.iloc[-1].to_dict()
                     print("市场活跃度数据获取成功")
@@ -577,7 +592,9 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
                 print(f"获取市场活跃度数据出错(乐股): {act_e}")
                 # 尝试替代方法 - 使用东财沪深京A股成交量作为活跃度指标
                 try:
-                    df_volume = ak.stock_zh_a_spot_em()
+                    from . import akshare_utils
+
+                    df_volume = akshare_utils.get_stock_realtime_snapshot(ttl_seconds=30)
                     if not df_volume.empty:
                         # 计算总成交量和总成交额
                         total_volume = df_volume['成交量'].sum() if '成交量' in df_volume.columns else 0
@@ -641,6 +658,8 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
             }
             print("合成市场情绪数据创建成功")
         
+        _SENTIMENT_CACHE["timestamp"] = time.time()
+        _SENTIMENT_CACHE["data"] = dict(result)
         return result
     except Exception as e:
         print(f"获取股市情绪指标时出错: {str(e)}")

--- a/deepseek_finrobot/data_source/cn_news_utils.py
+++ b/deepseek_finrobot/data_source/cn_news_utils.py
@@ -6,6 +6,7 @@ import akshare as ak
 import pandas as pd
 from typing import Dict, List, Optional, Union, Any
 import datetime
+import json
 import re
 import requests
 from bs4 import BeautifulSoup
@@ -312,6 +313,25 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
         股市情绪指标字典
     """
     try:
+        try:
+            # region agent log
+            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+                json.dumps(
+                    {
+                        "hypothesisId": "B",
+                        "location": "cn_news_utils.py:314",
+                        "message": "get_stock_market_sentiment_entry",
+                        "data": {},
+                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+            # endregion
+        except Exception:
+            pass
+
         result = {}
         api_success = False  # 标记是否有API调用成功
         
@@ -395,6 +415,9 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
         try:
             north_data = None
             api_found = False
+            north_api_attempts = 0
+            north_api_failures = 0
+            north_selected_api = None
             
             # 尝试所有可能的北向资金API
             possible_apis = [
@@ -428,6 +451,7 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
             ]
             
             for api_name, api_params in possible_apis:
+                north_api_attempts += 1
                 try:
                     api_func = getattr(ak, api_name, None)
                     if api_func:
@@ -435,13 +459,38 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
                         north_data = api_func(**api_params)
                         if not north_data.empty:
                             api_found = True
+                            north_selected_api = api_name
                             print(f"成功获取北向资金数据，使用API: {api_name}")
                             # 打印列名以便调试
                             print(f"北向资金数据列名: {north_data.columns.tolist()}")
                             break
                 except Exception as api_e:
+                    north_api_failures += 1
                     print(f"尝试API {api_name} 失败: {api_e}")
                     continue
+            try:
+                # region agent log
+                open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
+                    json.dumps(
+                        {
+                            "hypothesisId": "B",
+                            "location": "cn_news_utils.py:430",
+                            "message": "north_flow_api_attempt_summary",
+                            "data": {
+                                "attempts": north_api_attempts,
+                                "failures": north_api_failures,
+                                "api_found": api_found,
+                                "selected_api": north_selected_api,
+                            },
+                            "timestamp": int(datetime.datetime.now().timestamp() * 1000),
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+                # endregion
+            except Exception:
+                pass
                 
             if api_found and not north_data.empty:
                 # 确定关键列

--- a/deepseek_finrobot/data_source/cn_news_utils.py
+++ b/deepseek_finrobot/data_source/cn_news_utils.py
@@ -6,8 +6,6 @@ import akshare as ak
 import pandas as pd
 from typing import Dict, List, Optional, Union, Any
 import datetime
-import json
-import os
 import re
 import time
 import requests
@@ -350,25 +348,6 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
         if isinstance(cached_data, dict) and (time.time() - cached_ts) < cache_ttl_seconds:
             return dict(cached_data)
 
-        try:
-            # region agent log
-            os.makedirs("/opt/cursor/logs", exist_ok=True)
-            open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-                json.dumps(
-                    {
-                        "hypothesisId": "B",
-                        "location": "cn_news_utils.py:314",
-                        "message": "get_stock_market_sentiment_entry",
-                        "data": {},
-                        "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                    },
-                    ensure_ascii=False,
-                )
-                + "\n"
-            )
-            # endregion
-        except Exception:
-            pass
 
         result = {}
         api_success = False  # 标记是否有API调用成功
@@ -483,31 +462,6 @@ def get_stock_market_sentiment() -> Dict[str, Any]:
                     north_api_failures += 1
                     print(f"尝试API {api_name} 失败: {api_e}")
                     continue
-            try:
-                # region agent log
-                os.makedirs("/opt/cursor/logs", exist_ok=True)
-                open("/opt/cursor/logs/debug.log", "a", encoding="utf-8").write(
-                    json.dumps(
-                        {
-                            "hypothesisId": "B",
-                            "location": "cn_news_utils.py:430",
-                            "message": "north_flow_api_attempt_summary",
-                            "data": {
-                                "attempts": north_api_attempts,
-                                "failures": north_api_failures,
-                                "api_found": api_found,
-                                "selected_api": north_selected_api,
-                            },
-                            "timestamp": int(datetime.datetime.now().timestamp() * 1000),
-                        },
-                        ensure_ascii=False,
-                    )
-                    + "\n"
-                )
-                # endregion
-            except Exception:
-                pass
-                
             if api_found and not north_data.empty:
                 # 确定关键列
                 date_col = None

--- a/deepseek_finrobot/openai_adapter.py
+++ b/deepseek_finrobot/openai_adapter.py
@@ -120,7 +120,7 @@ def get_chat_completion(
 
 def get_llm_config_for_autogen(api_key: Optional[str] = None, **kwargs) -> Dict[str, Any]:
     """
-    获取适用于autogen的LLM配置 (兼容新版autogen)
+    获取适用于autogen的LLM配置 (兼容当前项目使用的 v0.2 接口)
     
     Args:
         api_key: DeepSeek API密钥，如果为None则使用环境变量
@@ -142,7 +142,7 @@ def get_llm_config_for_autogen(api_key: Optional[str] = None, **kwargs) -> Dict[
         "model": kwargs.get("model", "deepseek-chat"),
     }
     
-    # 构建配置列表 (适配新版autogen)
+    # 构建配置列表 (适配当前项目使用的 autogen v0.2 风格)
     base_url = kwargs.get("base_url", "https://api.deepseek.com/v1")
     config_list = [{
         "model": config["model"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # OpenAI和AutoGen相关
 openai>=1.72.0  # 新版API，需要与pyautogen兼容
-pyautogen>=0.8.5  # 需要Rust编译，与新版openai兼容
+pyautogen==0.2.35  # 锁定到支持 `import autogen` 的 v0.2 API
 
 # 选项3：最小依赖（仅基本功能）
 requests>=2.31.0  # 用于API请求

--- a/tests/test_network_resilience.py
+++ b/tests/test_network_resilience.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+
+from deepseek_finrobot.agents.selection_agent import StockSelectorAgent
+from deepseek_finrobot.data_source import akshare_utils, cn_news_utils
+
+
+def test_get_stock_industry_list_fallback_normalizes_board_code(monkeypatch):
+    def mock_primary():
+        raise RuntimeError("primary api failed")
+
+    def mock_fallback(indicator=None):
+        return pd.DataFrame({"label": ["BK0475"], "板块": ["银行"]})
+
+    monkeypatch.setattr(akshare_utils.ak, "stock_board_industry_name_em", mock_primary)
+    monkeypatch.setattr(akshare_utils.ak, "stock_sector_spot", mock_fallback)
+
+    df = akshare_utils.get_stock_industry_list()
+    assert "板块名称" in df.columns
+    assert "板块代码" in df.columns
+    assert str(df.iloc[0]["板块代码"]) == "BK0475"
+
+
+def test_get_stock_market_sentiment_uses_cache(monkeypatch):
+    cn_news_utils._SENTIMENT_CACHE["timestamp"] = 0.0
+    cn_news_utils._SENTIMENT_CACHE["data"] = None
+
+    calls = {"index": 0, "north": 0, "activity": 0}
+
+    def mock_index_spot():
+        calls["index"] += 1
+        return pd.DataFrame({"名称": ["上证指数"], "涨跌幅": [0.5], "最新价": [3100]})
+
+    def mock_north_hist():
+        calls["north"] += 1
+        return pd.DataFrame({"日期": ["2026-03-24"], "当日资金流入": [12.3]})
+
+    def mock_activity():
+        calls["activity"] += 1
+        return pd.DataFrame([{"日期": "2026-03-24", "活跃度": "中等"}])
+
+    monkeypatch.setattr(cn_news_utils.ak, "stock_zh_index_spot_sina", mock_index_spot)
+    monkeypatch.setattr(cn_news_utils.ak, "stock_hsgt_hist_em", mock_north_hist)
+    monkeypatch.setattr(cn_news_utils.ak, "stock_market_activity_legu", mock_activity)
+    if hasattr(cn_news_utils.ak, "stock_em_hsgt_north_net_flow_in_hist"):
+        monkeypatch.setattr(cn_news_utils.ak, "stock_em_hsgt_north_net_flow_in_hist", lambda: pd.DataFrame())
+    if hasattr(cn_news_utils.ak, "stock_hsgt_north_net_flow_em"):
+        monkeypatch.setattr(cn_news_utils.ak, "stock_hsgt_north_net_flow_em", lambda: pd.DataFrame())
+
+    first = cn_news_utils.get_stock_market_sentiment()
+    second = cn_news_utils.get_stock_market_sentiment()
+
+    assert "market_trend" in first
+    assert "north_flow" in first
+    assert first == second
+    assert calls["index"] == 1
+    assert calls["north"] == 1
+    assert calls["activity"] == 1
+
+
+def test_get_stock_info_reuses_snapshot_cache(monkeypatch):
+    akshare_utils._SPOT_CACHE["timestamp"] = 0.0
+    akshare_utils._SPOT_CACHE["data"] = None
+
+    calls = {"spot": 0}
+
+    def mock_info(symbol):
+        return pd.DataFrame({"item": ["股票简称"], "value": [f"name-{symbol}"]})
+
+    def mock_spot():
+        calls["spot"] += 1
+        return pd.DataFrame(
+            {
+                "代码": ["000001", "000002"],
+                "最新价": [10.0, 11.0],
+                "市盈率-动态": [5.0, 6.0],
+                "市净率": [1.0, 1.1],
+                "行业": ["银行", "银行"],
+                "涨跌幅": [0.1, 0.2],
+                "成交量": [1000, 1200],
+                "换手率": [0.5, 0.6],
+                "总市值": [100000, 120000],
+                "流通市值": [80000, 90000],
+            }
+        )
+
+    monkeypatch.setattr(akshare_utils.ak, "stock_individual_info_em", mock_info)
+    monkeypatch.setattr(akshare_utils.ak, "stock_zh_a_spot_em", mock_spot)
+
+    r1 = akshare_utils.get_stock_info("000001")
+    r2 = akshare_utils.get_stock_info("000002")
+
+    assert "error" not in r1
+    assert "error" not in r2
+    assert calls["spot"] == 1
+
+
+def test_selection_agent_skips_symbol_collection_error(monkeypatch):
+    selector = StockSelectorAgent(llm_config=None)
+
+    def mock_collect(symbol):
+        if symbol == "BAD":
+            raise RuntimeError("network error")
+        return {
+            "symbol": symbol,
+            "name": symbol,
+            "industry": "测试",
+            "raw_metrics": {
+                "momentum_raw": 0.1,
+                "trend_win_rate": 0.5,
+                "volatility_raw": 0.2,
+                "valuation_raw": 10.0,
+                "liquidity_raw": 1000.0,
+                "quality_raw": 1.0,
+                "pe": 10.0,
+                "pb": 1.0,
+                "roe": 12.0,
+                "profit_growth": 8.0,
+                "revenue_growth": 7.0,
+            },
+        }
+
+    monkeypatch.setattr(selector, "_collect_symbol_metrics", mock_collect)
+    monkeypatch.setattr(cn_news_utils, "get_stock_market_sentiment", lambda: {"market_trend": {"sentiment": "中性", "trend": "震荡"}})
+
+    result = selector.select_stocks(symbols=["BAD", "GOOD"], top_n=1)
+    assert "error" not in result
+    assert result["selected_symbols"] == ["GOOD"]

--- a/tests/test_stock_selector.py
+++ b/tests/test_stock_selector.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+StockSelectorAgent tests
+"""
+
+from typing import Any, Dict
+
+import pandas as pd
+
+from deepseek_finrobot.agents.selection_agent import StockSelectorAgent
+
+
+def _mock_get_stock_info(symbol: str) -> Dict[str, Any]:
+    mapping = {
+        "000001": {"股票简称": "平安银行", "所处行业": "银行", "市盈率(动态)": 5.0, "市净率": 0.7, "成交量": 1_000_000},
+        "600036": {"股票简称": "招商银行", "所处行业": "银行", "市盈率(动态)": 6.0, "市净率": 0.9, "成交量": 1_200_000},
+        "600519": {"股票简称": "贵州茅台", "所处行业": "白酒", "市盈率(动态)": 22.0, "市净率": 8.0, "成交量": 300_000},
+        "000858": {"股票简称": "五粮液", "所处行业": "白酒", "市盈率(动态)": 18.0, "市净率": 6.0, "成交量": 500_000},
+    }
+    return mapping.get(symbol, {"error": "not found"})
+
+
+def _mock_get_stock_history(symbol: str, **kwargs):
+    # 构造不同强度的价格序列：银行较稳，茅台动量强，五粮液中等
+    if symbol == "600519":
+        close = [100 + i * 1.0 for i in range(100)]  # 强动量
+    elif symbol == "000858":
+        close = [100 + i * 0.6 for i in range(100)]  # 中等动量
+    elif symbol == "600036":
+        close = [100 + i * 0.35 for i in range(100)]  # 稳健
+    else:
+        close = [100 + i * 0.3 for i in range(100)]  # 稳健
+
+    volume = [1_000_000 + i * 1000 for i in range(100)]
+    df = pd.DataFrame({"收盘": close, "成交量": volume})
+    return df
+
+
+def _mock_get_stock_financial_indicator(symbol: str):
+    # 银行质量高于白酒，用于保守偏好测试
+    if symbol in {"000001", "600036"}:
+        return pd.DataFrame(
+            {
+                "净资产收益率(%)": [14.5],
+                "净利润同比增长率(%)": [9.0],
+                "营业收入同比增长率(%)": [7.5],
+            }
+        )
+    return pd.DataFrame(
+        {
+            "净资产收益率(%)": [11.0],
+            "净利润同比增长率(%)": [18.0],
+            "营业收入同比增长率(%)": [16.0],
+        }
+    )
+
+
+def _mock_market_sentiment():
+    return {"market_trend": {"sentiment": "中性", "trend": "震荡"}}
+
+
+def test_stock_selector_returns_ranked_and_selected(monkeypatch):
+    from deepseek_finrobot.data_source import akshare_utils, cn_news_utils
+
+    monkeypatch.setattr(akshare_utils, "get_stock_info", _mock_get_stock_info)
+    monkeypatch.setattr(akshare_utils, "get_stock_history", _mock_get_stock_history)
+    monkeypatch.setattr(akshare_utils, "get_stock_financial_indicator", _mock_get_stock_financial_indicator)
+    monkeypatch.setattr(cn_news_utils, "get_stock_market_sentiment", _mock_market_sentiment)
+
+    selector = StockSelectorAgent(llm_config=None)
+    result = selector.select_stocks(
+        symbols=["000001", "600036", "600519", "000858"],
+        top_n=3,
+        risk_preference="中等",
+        investment_horizon="中期",
+        max_per_industry=2,
+        use_consensus=False,
+    )
+
+    assert "error" not in result
+    assert len(result["ranked_candidates"]) == 4
+    assert len(result["selected_symbols"]) == 3
+    assert all(item["score"] >= 0.0 and item["score"] <= 1.0 for item in result["ranked_candidates"])
+
+
+def test_stock_selector_industry_cap_works(monkeypatch):
+    from deepseek_finrobot.data_source import akshare_utils, cn_news_utils
+
+    monkeypatch.setattr(akshare_utils, "get_stock_info", _mock_get_stock_info)
+    monkeypatch.setattr(akshare_utils, "get_stock_history", _mock_get_stock_history)
+    monkeypatch.setattr(akshare_utils, "get_stock_financial_indicator", _mock_get_stock_financial_indicator)
+    monkeypatch.setattr(cn_news_utils, "get_stock_market_sentiment", _mock_market_sentiment)
+
+    selector = StockSelectorAgent(llm_config=None)
+    result = selector.select_stocks(
+        symbols=["000001", "600036", "600519", "000858"],
+        top_n=3,
+        risk_preference="中等",
+        investment_horizon="中期",
+        max_per_industry=1,
+        use_consensus=False,
+    )
+
+    selected = result["selected_candidates"]
+    industry_count = {}
+    for item in selected:
+        industry = item["industry"]
+        industry_count[industry] = industry_count.get(industry, 0) + 1
+
+    assert len(result["selected_symbols"]) == 3
+    # 即便补齐逻辑存在，优先阶段行业约束应生效，最终也不应出现严重集中
+    assert max(industry_count.values()) <= 2
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pin `pyautogen` to `0.2.35` to ensure compatibility with current `import autogen` code paths
- add `StockSelectorAgent` with smarter multi-factor stock selection (momentum, volatility, valuation, liquidity, quality)
- add adaptive factor weighting by risk preference and investment horizon
- add industry diversification constraint (`max_per_industry`) and market-regime biasing
- add optional AutoGen GroupChat consensus mode (`--consensus`) with quant/fundamental/risk roles
- add new CLI command `select` for intelligent stock screening from manual symbols, industry, or concept universe
- add tests for the new selector behavior and keep all existing tests passing
- harden AKShare data fetching for unstable network paths:
  - fallback column normalization for industry list + fallback APIs
  - bounded retries and safer fallback for market sentiment APIs
  - safer behavior when realtime snapshot endpoint is unavailable
  - remove temporary debug instrumentation logs after diagnosis

## Validation
- `python3 -m pytest tests/test_stock_selector.py -v` (2 passed)
- `python3 -m deepseek_finrobot.cli --help` (includes `select` command)
- `python3 -m pytest tests/ -v` (13 passed)
- connectivity diagnostics:
  - direct `requests` to CN finance domains returned HTTP 200
  - AKShare calls showed intermittent `RemoteDisconnected`, confirming unstable upstream path rather than total block

## Root cause diagnosis
- Not a total region block; network reachability exists.
- Primary issue is intermittent upstream disconnects (`RemoteDisconnected`) amplified by high-frequency AKShare request patterns and fallback storms.
- Added guardrails now reduce failure impact and avoid hard crashes in selection flow.

## Notes
- Existing commands and behaviors remain backward-compatible.
- New GroupChat consensus is opt-in and requires configured LLM key via existing config flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efd0a6c8-8f6d-44ee-aa8c-fdc7595da02c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efd0a6c8-8f6d-44ee-aa8c-fdc7595da02c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

